### PR TITLE
infra/baseline-v33: Agent resilience with API retry

### DIFF
--- a/src/swf_common_lib/api_utils.py
+++ b/src/swf_common_lib/api_utils.py
@@ -5,7 +5,74 @@ These utilities are shared between BaseAgent and other components that need
 to interact with the swf-monitor REST API but don't inherit from BaseAgent.
 """
 
+import time
 import logging
+import requests
+
+
+RETRY_DELAYS = (2, 4, 8, 20)
+RETRYABLE_STATUS_CODES = {502, 503, 504}
+
+
+def api_request_with_retry(method, url, session=None, logger=None, **kwargs):
+    """
+    Make an HTTP request with exponential backoff retry on transient failures.
+
+    Retries on: ConnectionError, Timeout, 502/503/504.
+    Fails immediately on: 4xx, redirects, other errors.
+
+    Args:
+        method: HTTP method ('get', 'post', etc.)
+        url: Full URL
+        session: requests.Session to use (falls back to requests module)
+        logger: Logger instance
+        **kwargs: Passed to requests (json, timeout, etc.)
+
+    Returns:
+        requests.Response on success
+
+    Raises:
+        requests.exceptions.RequestException on final failure
+    """
+    if logger is None:
+        logger = logging.getLogger(__name__)
+    if session is None:
+        session = requests
+
+    kwargs.setdefault('timeout', 10)
+
+    last_exception = None
+    for attempt in range(len(RETRY_DELAYS) + 1):
+        try:
+            response = session.request(method, url, **kwargs)
+
+            if response.status_code in RETRYABLE_STATUS_CODES:
+                if attempt < len(RETRY_DELAYS):
+                    delay = RETRY_DELAYS[attempt]
+                    logger.warning(
+                        f"Retryable HTTP {response.status_code} from {method.upper()} {url}, "
+                        f"retry {attempt + 1}/{len(RETRY_DELAYS)} in {delay}s"
+                    )
+                    time.sleep(delay)
+                    continue
+                else:
+                    response.raise_for_status()
+
+            return response
+
+        except (requests.exceptions.ConnectionError, requests.exceptions.Timeout) as e:
+            last_exception = e
+            if attempt < len(RETRY_DELAYS):
+                delay = RETRY_DELAYS[attempt]
+                logger.warning(
+                    f"{type(e).__name__} on {method.upper()} {url}, "
+                    f"retry {attempt + 1}/{len(RETRY_DELAYS)} in {delay}s"
+                )
+                time.sleep(delay)
+            else:
+                raise
+
+    raise last_exception
 
 
 def get_next_agent_id(monitor_url, api_session, logger=None):
@@ -28,14 +95,14 @@ def get_next_agent_id(monitor_url, api_session, logger=None):
 
     try:
         url = f"{monitor_url}/api/state/next-agent-id/"
-        response = api_session.post(url, timeout=10)
+        response = api_request_with_retry('post', url, session=api_session, logger=logger)
         response.raise_for_status()
 
         data = response.json()
         if data.get('status') == 'success':
             agent_id = data.get('agent_id')
             logger.info(f"Got next agent ID from persistent state: {agent_id}")
-            return str(agent_id)  # Return as string for consistency
+            return str(agent_id)
         else:
             raise RuntimeError(f"API returned error: {data.get('error', 'Unknown error')}")
 
@@ -64,14 +131,14 @@ def get_next_run_number(monitor_url, api_session, logger=None):
 
     try:
         url = f"{monitor_url}/api/state/next-run-number/"
-        response = api_session.post(url, timeout=10)
+        response = api_request_with_retry('post', url, session=api_session, logger=logger)
         response.raise_for_status()
 
         data = response.json()
         if data.get('status') == 'success':
             run_number = data.get('run_number')
             logger.info(f"Got next run number from persistent state: {run_number}")
-            return str(run_number)  # Return as string for consistency
+            return str(run_number)
         else:
             raise RuntimeError(f"API returned error: {data.get('error', 'Unknown error')}")
 
@@ -108,7 +175,7 @@ def ensure_namespace(monitor_url, api_session, name, owner=None, logger=None):
     try:
         url = f"{monitor_url}/api/namespaces/ensure/"
         payload = {'name': name, 'owner': owner}
-        response = api_session.post(url, json=payload, timeout=10)
+        response = api_request_with_retry('post', url, session=api_session, logger=logger, json=payload)
         response.raise_for_status()
 
         data = response.json()

--- a/src/swf_common_lib/base_agent.py
+++ b/src/swf_common_lib/base_agent.py
@@ -13,7 +13,7 @@ import json
 import logging
 from pathlib import Path
 from typing import Optional
-from .api_utils import get_next_agent_id
+from .api_utils import get_next_agent_id, api_request_with_retry
 from .config_utils import load_testbed_config, TestbedConfigError
 
 
@@ -582,35 +582,35 @@ class BaseAgent(stomp.ConnectionListener):
     def _api_request(self, method, endpoint, json_data=None):
         """
         Helper method to make a request to the monitor API.
-        FAILS FAST - raises exception on any API error.
+        Retries on transient failures (connection errors, 502/503/504).
+        Fails immediately on 4xx and redirects.
         """
         url = f"{self.monitor_url}/api{endpoint}"
         try:
-            # Do not follow redirects; 3xx usually indicates upstream auth middleware (e.g., OIDC)
-            response = self.api.request(method, url, json=json_data, timeout=10, allow_redirects=False)
-            # Treat redirect as auth/config problem with a clear message
+            response = api_request_with_retry(
+                method, url, session=self.api, logger=logging.getLogger(__name__),
+                json=json_data, allow_redirects=False,
+            )
             if 300 <= response.status_code < 400:
                 loc = response.headers.get('Location', 'unknown')
                 msg = (f"API redirect (HTTP {response.status_code}) to {loc}. "
                        f"If behind Apache/OIDC, ensure API requests aren't redirected and Authorization is forwarded.")
                 logging.error(msg)
                 raise APIError(msg, response=response, url=url, method=method.upper())
-            response.raise_for_status()  # Raise an exception for bad status codes
+            response.raise_for_status()
             return response.json()
         except requests.exceptions.RequestException as e:
-            # Check for "already exists" error in subscriber registration
             if hasattr(e, 'response') and e.response is not None and e.response.status_code == 400:
                 response_text = e.response.text.lower()
                 if "already exists" in response_text and "subscriber" in response_text:
-                    # This is a normal "already exists" case for subscriber registration
                     logging.info(f"Resource already exists (normal): {method.upper()} {url}")
                     return {"status": "already_exists"}
-            
+
             logging.error(f"API request FAILED: {method.upper()} {url} - {e}")
             if hasattr(e, 'response') and e.response is not None:
                 logging.error(f"Response status: {e.response.status_code}")
                 logging.error(f"Response body: {e.response.text}")
-            raise APIError(f"Critical API failure - agent cannot continue: {method.upper()} {url} - {e}", 
+            raise APIError(f"Critical API failure - agent cannot continue: {method.upper()} {url} - {e}",
                           response=getattr(e, 'response', None), url=url, method=method.upper()) from e
 
     def send_heartbeat(self):


### PR DESCRIPTION
## infra/baseline-v33

Coordinated release across swf-monitor (188 commits), swf-testbed (18 commits), swf-common-lib (2 commits).

See swf-monitor PR for full release notes: https://github.com/BNLNPPS/swf-monitor/pull/28

### swf-common-lib changes (2 commits)

- Agent resilience: API retry with exponential backoff
- v32 branch sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)