### PR TITLE
SWF v41 baseline: episodes engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,74 @@ The wrapper:
 - **skips** the call when `dedup_key` names a unit already running, avoiding the
   duplicate-work race that concurrency introduces.
 
+#### Concurrency contract and safe migration
+
+`run_in_background` changes two things independently:
+
+1. the STOMP receiver becomes responsive because work moves off that thread;
+2. unless configured otherwise, different background calls may run
+   concurrently.
+
+The pool uses `SWF_AGENT_MAX_WORKERS`, defaulting to **4**. Calls with different
+`dedup_key` values can therefore overlap. A dedup key only suppresses a second
+copy of the *same* in-flight unit; it is not a mutex, queue, or serialization
+key.
+
+For the first migration of an existing serial handler, set:
+
+```bash
+export SWF_AGENT_MAX_WORKERS=1
+```
+
+This keeps the receiver and heartbeats responsive while preserving the
+handler's former one-at-a-time execution. Increase the worker count only after
+auditing the complete doer path for concurrency:
+
+- keep run IDs, dataset names, temporary paths, and other per-message values in
+  function locals instead of mutable `self.*` fields;
+- do not concurrently change the process working directory or environment;
+- use unique temporary directories and filenames;
+- verify that libraries, command wrappers, clients, and shared sessions are
+  thread-safe;
+- retain a semantic `dedup_key` even when execution is serialized, because it
+  prevents duplicate delivery of the same unit.
+
+If most work is safe to overlap but one component is not, serialize that
+component with a lock owned by the agent:
+
+```python
+import threading
+
+class ProcessingAgent(BaseAgent):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._prun_lock = threading.Lock()
+
+    def on_message(self, frame):
+        message = decode_and_validate(frame)
+        self.run_in_background(
+            self._do_submit,
+            message,
+            dedup_key=f"submit:{message['run_id']}:{message['site']}",
+            label="submit PanDA task",
+        )
+
+    def _do_submit(self, message):
+        # Per-message values stay local. Independent preparation may overlap.
+        prun_args = build_prun_args(message)
+        with self._prun_lock:
+            # Protect the complete non-thread-safe operation, including its
+            # sandbox creation and submission-side process-global state.
+            params = PrunScript.main(True, prun_args)
+            return submit_task(params)
+```
+
+Acquire the lock in the background doer, not in `on_message`; taking it on the
+receiver thread recreates the heartbeat problem. Use one process-wide lock for
+a process-global library such as `PrunScript`, not one lock per site. Setting
+`SWF_AGENT_MAX_WORKERS=1` is preferable when the agent still has broader shared
+mutable state or when the whole operation was designed to be serial.
+
 Control messages (liveness, shutdown) should stay inline on the receiver thread;
 only long-running work is offloaded. Shutdown drains in-flight workers. See
 `swf-monitor/docs/EPICPROD_OPS_AGENT.md` for the first consumer.

--- a/src/swf_common_lib/base_agent.py
+++ b/src/swf_common_lib/base_agent.py
@@ -651,6 +651,9 @@ class BaseAgent(stomp.ConnectionListener):
 
         Raises:
             ValueError: If destination doesn't have /queue/ or /topic/ prefix
+            Exception: If the send fails and a reconnect-and-resend also
+                fails. A lost message is the caller's problem — swallowing
+                it here abandons downstream state (run 102780, 2026-07-30).
         """
         # Validate destination has explicit prefix
         if not destination.startswith('/queue/') and not destination.startswith('/topic/'):
@@ -674,21 +677,22 @@ class BaseAgent(stomp.ConnectionListener):
                 self.conn.send(body=json.dumps(message_body), destination=destination)
                 logging.info(f"Sent message to '{destination}': {message_body}")
             except Exception as e:
+                # Any send failure warrants one reconnect-and-resend; no
+                # error-string filtering — NotConnectedException stringifies
+                # without the word 'connection' and was slipping through.
                 logging.error(f"Failed to send message to '{destination}': {e}")
-
-                # Check for SSL/connection errors that indicate disconnection
-                if any(error_type in str(e).lower() for error_type in ['ssl', 'eof', 'connection', 'broken pipe']):
-                    logging.warning("Connection error detected - attempting recovery")
-                    self.mq_connected = False
-                    time.sleep(1)  # Brief pause before retry
-                    if self._attempt_reconnect():
-                        try:
-                            self.conn.send(body=json.dumps(message_body), destination=destination)
-                            logging.info(f"Message sent successfully after reconnection to '{destination}'")
-                        except Exception as retry_e:
-                            logging.error(f"Retry failed after reconnection: {retry_e}")
-                    else:
-                        logging.error("Reconnection failed - message lost")
+                self.mq_connected = False
+                time.sleep(1)  # Brief pause before retry
+                if not self._attempt_reconnect():
+                    logging.error(
+                        f"Reconnection failed - could not send to '{destination}'")
+                    raise
+                try:
+                    self.conn.send(body=json.dumps(message_body), destination=destination)
+                    logging.info(f"Message sent successfully after reconnection to '{destination}'")
+                except Exception as retry_e:
+                    logging.error(f"Retry failed after reconnection: {retry_e}")
+                    raise
 
     def _api_request(self, method, endpoint, json_data=None):
         """

--- a/src/swf_common_lib/base_agent.py
+++ b/src/swf_common_lib/base_agent.py
@@ -575,6 +575,14 @@ class BaseAgent(stomp.ConnectionListener):
           flight, this call is skipped and returns False — closing the
           duplicate-work race that concurrency introduces.
 
+        Calls with different keys can run concurrently: the pool has
+        ``SWF_AGENT_MAX_WORKERS`` threads (default 4). ``dedup_key`` is not a
+        lock and does not preserve the receiver thread's former serial
+        semantics. For a safe first migration, set ``SWF_AGENT_MAX_WORKERS=1``.
+        With a larger pool, keep per-message state local to ``fn`` and protect
+        any non-thread-safe library or CLI with a lock acquired inside the
+        background function, never in the receiver-thread handler.
+
         Do not mix with the inline ``processing()`` context manager in the same
         agent; both drive operational_state. Returns True if enqueued, False if
         deduplicated or the pool refused the task.

--- a/src/swf_common_lib/episodes.py
+++ b/src/swf_common_lib/episodes.py
@@ -160,6 +160,9 @@ class EpisodeContext:
         self.last_message: Optional[Dict] = None
         #: Scratch space for the definition (run ids, task ids, ...).
         self.notes: Dict = {}
+        #: Participant ids already reported, so steady message traffic
+        #: does not re-upsert its sender on every message.
+        self.seen_participants: set = set()
 
 
 class EpisodeBuilder:
@@ -205,7 +208,13 @@ class EpisodeBuilder:
                 )
             context.last_message = message
             event = definition.event_from_message(message)
-            participants = definition.participants_from_message(message)
+            participants = [
+                entry for entry in definition.participants_from_message(message)
+                if not (entry.get("id") in context.seen_participants
+                        and "died_at" not in entry)
+            ]
+            for entry in participants:
+                context.seen_participants.add(entry.get("id"))
             if event or participants:
                 self.ingest.append(
                     scope=definition.scope,

--- a/src/swf_common_lib/episodes.py
+++ b/src/swf_common_lib/episodes.py
@@ -92,6 +92,28 @@ class MonitorEpisodeIngest:
             "ended_at": ended_at, "summary": summary or {},
         })
 
+    def _get(self, path: str) -> Dict:
+        url = f"{self.base_url}/api/snapper/{path}"
+        try:
+            response = self.session.get(url, timeout=30)
+        except requests.RequestException as exc:
+            raise EpisodeIngestError(f"GET {url} failed: {exc}") from exc
+        if response.status_code >= 400:
+            raise EpisodeIngestError(
+                f"GET {url} returned {response.status_code}: "
+                f"{response.text[:500]}")
+        return response.json()
+
+    def open_episodes(self, scope: str) -> List[Dict]:
+        """The scope's episodes without a recorded end."""
+        listing = self._get(f"{scope}/episodes/")
+        return [e for e in listing.get("episodes", [])
+                if not e.get("ended_at")]
+
+    def episode(self, scope: str, episode_id: str) -> Dict:
+        """One episode's full record."""
+        return self._get(f"{scope}/episodes/{episode_id}/")
+
 
 class EpisodeDefinition:
     """The workflow-specific contract. Subclass per workflow.
@@ -197,11 +219,58 @@ class EpisodeBuilder:
         self.ingest = ingest
         self.active: Dict[str, EpisodeContext] = {}
 
+    def adopt_open_episodes(self) -> int:
+        """Adopt the builder identity's open episodes, so a restarted
+        builder resumes what its predecessor left live: an episode
+        whose end signal already passed is driven to completion and
+        close by the next ticks; one still mid-flight keeps appending
+        as its messages arrive. Returns the number adopted."""
+        adopted = 0
+        scopes = {d.scope for d in self.definitions if d.scope}
+        for scope in scopes:
+            try:
+                open_records = self.ingest.open_episodes(scope)
+            except EpisodeIngestError as exc:
+                logger.error("open-episode listing failed for %s: %s",
+                             scope, exc)
+                continue
+            for entry in open_records:
+                episode_id = entry.get("episode_id")
+                if not episode_id or episode_id in self.active:
+                    continue
+                definition = next(
+                    (d for d in self.definitions
+                     if d.scope == scope
+                     and d.workflow_name == entry.get("kind")), None)
+                if definition is None:
+                    continue
+                try:
+                    record = self.ingest.episode(scope, episode_id)
+                except EpisodeIngestError as exc:
+                    logger.error("episode fetch failed for %s: %s",
+                                 episode_id, exc)
+                    continue
+                context = EpisodeContext(definition, episode_id)
+                for event in record.get("events", []):
+                    context.seen_participants.add(event.get("participant"))
+                    if definition.is_end({"msg_type": event.get("kind")}):
+                        context.end_seen_at = utc_now_iso()
+                        context.ended_at = event.get("time")
+                self.active[episode_id] = context
+                adopted += 1
+                logger.info("adopted open episode %s (%s)", episode_id,
+                            "end seen" if context.end_seen_at
+                            else "still live")
+        return adopted
+
     def handle_message(self, message: Dict) -> bool:
         """Route one bus message; returns True if it joined an episode."""
         execution_id = message.get("execution_id")
         if not execution_id:
             return False
+        # Arrival stamp: the fallback event time for messages whose
+        # writer stamps no timestamp of its own.
+        message.setdefault("_received_at", utc_now_iso())
         for definition in self.definitions:
             if definition.matches(message):
                 break

--- a/src/swf_common_lib/episodes.py
+++ b/src/swf_common_lib/episodes.py
@@ -123,6 +123,19 @@ class EpisodeDefinition:
         run_id = message.get("run_id")
         return f"run {run_id}" if run_id else ""
 
+    def started_at(self, message: Dict) -> str:
+        """Timezone-aware ISO start for the episode. The default is the
+        arrival time; definitions that trust their messages' stamps
+        override this with a normalized message time."""
+        return utc_now_iso()
+
+    def ended_at(self, message: Dict) -> str:
+        """Timezone-aware ISO end for the episode, from the end-signal
+        message. Same default and override contract as started_at —
+        essential for backfilled episodes, whose close must carry the
+        recorded end rather than the replay time."""
+        return utc_now_iso()
+
     def event_from_message(self, message: Dict) -> Optional[Dict]:
         """Bus message -> event dict ``{time, kind, participant,
         counterpart?, payload?}``, or None to ignore the message."""
@@ -156,6 +169,7 @@ class EpisodeContext:
         self.episode_id = episode_id
         self.opened_at = utc_now_iso()
         self.end_seen_at: Optional[str] = None
+        self.ended_at: Optional[str] = None
         self.first_message: Optional[Dict] = None
         self.last_message: Optional[Dict] = None
         #: Scratch space for the definition (run ids, task ids, ...).
@@ -202,7 +216,7 @@ class EpisodeBuilder:
                 self.ingest.open(
                     scope=definition.scope,
                     episode_id=execution_id,
-                    started_at=message.get("timestamp") or utc_now_iso(),
+                    started_at=definition.started_at(message),
                     label=definition.label(message),
                     kind=definition.workflow_name,
                 )
@@ -224,6 +238,7 @@ class EpisodeBuilder:
                 )
             if definition.is_end(message):
                 context.end_seen_at = utc_now_iso()
+                context.ended_at = definition.ended_at(message)
             return True
         except EpisodeIngestError as exc:
             logger.error("episode ingest failed for %s: %s",
@@ -254,7 +269,7 @@ class EpisodeBuilder:
                 self.ingest.close(
                     scope=definition.scope,
                     episode_id=execution_id,
-                    ended_at=context.end_seen_at,
+                    ended_at=context.ended_at or context.end_seen_at,
                     summary=definition.summary(context),
                 )
             except EpisodeIngestError as exc:

--- a/src/swf_common_lib/episodes.py
+++ b/src/swf_common_lib/episodes.py
@@ -347,6 +347,8 @@ class EpisodeBuilder:
             del self.active[execution_id]
 
     def _deadline_passed(self, context: EpisodeContext) -> bool:
+        if context.end_seen_at is None:
+            return False
         seen = datetime.fromisoformat(context.end_seen_at)
         elapsed = datetime.now(timezone.utc) - seen
         return elapsed.total_seconds() > (

--- a/src/swf_common_lib/episodes.py
+++ b/src/swf_common_lib/episodes.py
@@ -1,0 +1,261 @@
+"""Episode building: the generic engine behind workflow episode records.
+
+An episode is a durable Snapper record of one bounded activity — a
+workflow execution — whose record is the event sequence at native
+resolution (snapper-ai docs/EPISODES.md). This module carries the
+workflow-agnostic machinery:
+
+- ``EpisodeDefinition`` — the contract a workflow-specific module
+  implements: which bus messages are events, how participants are
+  recognized, and the completion pass that joins late records.
+- ``EpisodeBuilder`` — the engine an agent drives: it watches bus
+  traffic, opens the episode on first sight of an execution, appends
+  events as they arrive, and runs the definition's completion pass
+  before closing.
+- ``MonitorEpisodeIngest`` — the REST client for the swf-monitor
+  episode ingest endpoints.
+
+A workflow gains an episode record by implementing one definition and
+naming it in the episode builder agent's configuration; nothing here
+changes.
+"""
+
+import logging
+from datetime import datetime, timezone
+from typing import Dict, List, Optional
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+
+def utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+class EpisodeIngestError(Exception):
+    """A rejected or failed episode ingest call."""
+
+
+class MonitorEpisodeIngest:
+    """REST client for the swf-monitor episode ingest endpoints.
+
+    Endpoints (token-authenticated):
+      POST {base}/api/snapper/episodes/open/
+      POST {base}/api/snapper/episodes/append/
+      POST {base}/api/snapper/episodes/close/
+    """
+
+    def __init__(self, base_url: str, token: str,
+                 builder_identity: str, session=None):
+        self.base_url = (base_url or "").rstrip("/")
+        self.builder_identity = builder_identity
+        self.session = session or requests.Session()
+        if token:
+            self.session.headers.update({"Authorization": f"Token {token}"})
+
+    def _post(self, path: str, payload: Dict) -> Dict:
+        url = f"{self.base_url}/api/snapper/episodes/{path}/"
+        payload = dict(payload, builder_identity=self.builder_identity)
+        try:
+            response = self.session.post(url, json=payload, timeout=30)
+        except requests.RequestException as exc:
+            raise EpisodeIngestError(f"POST {url} failed: {exc}") from exc
+        if response.status_code >= 400:
+            raise EpisodeIngestError(
+                f"POST {url} returned {response.status_code}: "
+                f"{response.text[:500]}"
+            )
+        return response.json()
+
+    def open(self, scope: str, episode_id: str, started_at: str,
+             label: str = "", kind: str = "",
+             summary: Optional[Dict] = None) -> Dict:
+        return self._post("open", {
+            "scope": scope, "episode_id": episode_id,
+            "started_at": started_at, "label": label, "kind": kind,
+            "summary": summary or {},
+        })
+
+    def append(self, scope: str, episode_id: str,
+               events: Optional[List[Dict]] = None,
+               participants: Optional[List[Dict]] = None) -> Dict:
+        return self._post("append", {
+            "scope": scope, "episode_id": episode_id,
+            "events": events or [], "participants": participants or [],
+        })
+
+    def close(self, scope: str, episode_id: str, ended_at: str,
+              summary: Optional[Dict] = None) -> Dict:
+        return self._post("close", {
+            "scope": scope, "episode_id": episode_id,
+            "ended_at": ended_at, "summary": summary or {},
+        })
+
+
+class EpisodeDefinition:
+    """The workflow-specific contract. Subclass per workflow.
+
+    The builder consults ``matches`` to route bus messages, converts
+    them through ``event_from_message`` / ``participants_from_message``,
+    and treats ``is_end`` as the execution's end signal. After the end
+    signal the builder calls ``completion_poll`` on every tick until it
+    returns True or ``completion_deadline_seconds`` passes, then closes
+    the episode.
+    """
+
+    #: Snapper scope the episodes belong to (e.g. 'testbed').
+    scope = ""
+    #: Workflow name this definition covers; used by the default
+    #: ``matches`` against the execution id prefix.
+    workflow_name = ""
+    #: Seconds after the end signal within which completion_poll must
+    #: finish; the episode closes regardless when the deadline passes.
+    completion_deadline_seconds = 1800
+
+    def matches(self, message: Dict) -> bool:
+        execution_id = message.get("execution_id") or ""
+        return bool(self.workflow_name) and execution_id.startswith(
+            f"{self.workflow_name}-"
+        )
+
+    def label(self, message: Dict) -> str:
+        run_id = message.get("run_id")
+        return f"run {run_id}" if run_id else ""
+
+    def event_from_message(self, message: Dict) -> Optional[Dict]:
+        """Bus message -> event dict ``{time, kind, participant,
+        counterpart?, payload?}``, or None to ignore the message."""
+        raise NotImplementedError
+
+    def participants_from_message(self, message: Dict) -> List[Dict]:
+        """Bus message -> participant upserts ``[{id, label?, kind?,
+        born_at?, died_at?, detail?}]``."""
+        return []
+
+    def is_end(self, message: Dict) -> bool:
+        return message.get("msg_type") == "end_run"
+
+    def completion_poll(self, context: "EpisodeContext",
+                        ingest: MonitorEpisodeIngest) -> bool:
+        """Join late records (workload states, registries) by appending
+        further events and participants; return True when complete.
+        Called repeatedly after the end signal until True or deadline."""
+        return True
+
+    def summary(self, context: "EpisodeContext") -> Dict:
+        """The episode's closing summary document."""
+        return {}
+
+
+class EpisodeContext:
+    """Mutable per-execution state the builder shares with a definition."""
+
+    def __init__(self, definition: EpisodeDefinition, episode_id: str):
+        self.definition = definition
+        self.episode_id = episode_id
+        self.opened_at = utc_now_iso()
+        self.end_seen_at: Optional[str] = None
+        self.first_message: Optional[Dict] = None
+        self.last_message: Optional[Dict] = None
+        #: Scratch space for the definition (run ids, task ids, ...).
+        self.notes: Dict = {}
+
+
+class EpisodeBuilder:
+    """The engine: routes bus messages to armed definitions and drives
+    each execution's episode through open, append, completion, close.
+
+    The driving agent calls ``handle_message`` for every bus message it
+    receives and ``tick`` periodically (heartbeat cadence is enough);
+    ticks run completion polls and close episodes past their deadline.
+    Ingest failures are logged and surfaced through the return values;
+    the builder never raises out of ``handle_message`` or ``tick`` so a
+    broken ingest cannot take the listening agent down with it.
+    """
+
+    def __init__(self, definitions: List[EpisodeDefinition],
+                 ingest: MonitorEpisodeIngest):
+        self.definitions = list(definitions)
+        self.ingest = ingest
+        self.active: Dict[str, EpisodeContext] = {}
+
+    def handle_message(self, message: Dict) -> bool:
+        """Route one bus message; returns True if it joined an episode."""
+        execution_id = message.get("execution_id")
+        if not execution_id:
+            return False
+        for definition in self.definitions:
+            if definition.matches(message):
+                break
+        else:
+            return False
+        try:
+            context = self.active.get(execution_id)
+            if context is None:
+                context = EpisodeContext(definition, execution_id)
+                context.first_message = message
+                self.active[execution_id] = context
+                self.ingest.open(
+                    scope=definition.scope,
+                    episode_id=execution_id,
+                    started_at=message.get("timestamp") or utc_now_iso(),
+                    label=definition.label(message),
+                    kind=definition.workflow_name,
+                )
+            context.last_message = message
+            event = definition.event_from_message(message)
+            participants = definition.participants_from_message(message)
+            if event or participants:
+                self.ingest.append(
+                    scope=definition.scope,
+                    episode_id=execution_id,
+                    events=[event] if event else [],
+                    participants=participants,
+                )
+            if definition.is_end(message):
+                context.end_seen_at = utc_now_iso()
+            return True
+        except EpisodeIngestError as exc:
+            logger.error("episode ingest failed for %s: %s",
+                         execution_id, exc)
+            return False
+
+    def tick(self) -> None:
+        """Drive pending completions; safe to call at any cadence."""
+        for execution_id in list(self.active):
+            context = self.active[execution_id]
+            if context.end_seen_at is None:
+                continue
+            definition = context.definition
+            try:
+                done = definition.completion_poll(context, self.ingest)
+            except Exception as exc:
+                logger.error("completion poll failed for %s: %s",
+                             execution_id, exc)
+                done = False
+            deadline_passed = self._deadline_passed(context)
+            if not done and not deadline_passed:
+                continue
+            if deadline_passed and not done:
+                logger.warning(
+                    "episode %s closed at completion deadline with the "
+                    "completion pass unfinished", execution_id)
+            try:
+                self.ingest.close(
+                    scope=definition.scope,
+                    episode_id=execution_id,
+                    ended_at=context.end_seen_at,
+                    summary=definition.summary(context),
+                )
+            except EpisodeIngestError as exc:
+                logger.error("episode close failed for %s: %s",
+                             execution_id, exc)
+            del self.active[execution_id]
+
+    def _deadline_passed(self, context: EpisodeContext) -> bool:
+        seen = datetime.fromisoformat(context.end_seen_at)
+        elapsed = datetime.now(timezone.utc) - seen
+        return elapsed.total_seconds() > (
+            context.definition.completion_deadline_seconds
+        )


### PR DESCRIPTION
Baseline PR for the v41 cycle. The episodes module: a generic episode-building engine with definition hooks for start and end times, builder adoption, ingest reads, arrival stamps, and single reporting per participant. send_message raises on unrecoverable failure instead of swallowing it.

Canonical release record: RELEASE_NOTES.md v41 entry in swf-testbed PR https://github.com/BNLNPPS/swf-testbed/pull/69
Companion: swf-monitor PR https://github.com/BNLNPPS/swf-monitor/pull/46

🤖 Generated with [Claude Code](https://claude.com/claude-code)